### PR TITLE
Fixed statement on weeks

### DIFF
--- a/notebooks/BikeShareExample.ipynb
+++ b/notebooks/BikeShareExample.ipynb
@@ -975,7 +975,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Forecast horizon is how long in future the forecast should be predicting. For weekly data, a value of 12 means 1 weeks. Our example is hourly data, we try forecast the next day, so we can set to 24."
+    "Forecast horizon is how long in future the forecast should be predicting. For weekly data, a value of 12 means 12 weeks. Our example is hourly data, we try forecast the next day, so we can set to 24."
    ]
   },
   {
@@ -1938,9 +1938,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1952,7 +1952,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/Getting_started_with_Forecast.ipynb
+++ b/notebooks/Getting_started_with_Forecast.ipynb
@@ -437,7 +437,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Forecast horizon is how long in future the forecast should be predicting. For weekly data, a value of 12 means 1 weeks. Our example is hourly data, we try forecast the next day, so we can set to 24."
+    "Forecast horizon is how long in future the forecast should be predicting. For weekly data, a value of 12 means 12 weeks. Our example is hourly data, we try forecast the next day, so we can set to 24."
    ]
   },
   {
@@ -735,9 +735,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -749,7 +749,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/Getting_started_with_Forecast_and_AutoML.ipynb
+++ b/notebooks/Getting_started_with_Forecast_and_AutoML.ipynb
@@ -437,7 +437,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Forecast horizon is how long in future the forecast should be predicting. For weekly data, a value of 12 means 1 weeks. Our example is hourly data, we try forecast the next day, so we can set to 24."
+    "Forecast horizon is how long in future the forecast should be predicting. For weekly data, a value of 12 means 12 weeks. Our example is hourly data, we try forecast the next day, so we can set to 24."
    ]
   },
   {
@@ -765,9 +765,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -779,7 +779,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.1"
   },
   "toc": {
    "collapse_to_match_collapsible_headings": false,


### PR DESCRIPTION
The content in the notebooks was incorrect on:

```
Forecast horizon is how long in future the forecast should be predicting. For weekly data, a value of 12 means 1 weeks. Our example is hourly data, we try forecast the next day, so we can set to 24.
```

I have changed it in all to:

```
Forecast horizon is how long in future the forecast should be predicting. For weekly data, a value of 12 means 12 weeks. Our example is hourly data, we try forecast the next day, so we can set to 24.
```