### PR TITLE
Add AWS CLI instructions to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ _What do I need to get started?_
  * Proper IAM User and role setup
  * An S3 bucket where your data is stored
 
+_How do I use control AWS Forecast resources using the aws cli?_
+
+ You can clone or download this repository and run `aws configure add-model --service-model [MODEL_JSON_FILE]`
+ on the files in `sdk`, eg `aws configure add-model --service-model forecast-2019-05-15.normal.json`
+
 _How do I contribute my own example notebook?_  
  Although we're extremely excited to receive contributions from the community, we're still working on the best mechanism to take in examples from external sources. Please bear with us in the short-term if pull requests take longer than expected or are closed.
  

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _What do I need to get started?_
 _How do I use control AWS Forecast resources using the aws cli?_
 
  You can clone or download this repository and run `aws configure add-model --service-model [MODEL_JSON_FILE]`
- on the files in `sdk`, eg `aws configure add-model --service-model forecast-2019-05-15.normal.json`
+ on the files in `sdk`, eg `aws configure add-model --service-model file://forecast-2019-05-15.normal.json`
 
 _How do I contribute my own example notebook?_  
  Although we're extremely excited to receive contributions from the community, we're still working on the best mechanism to take in examples from external sources. Please bear with us in the short-term if pull requests take longer than expected or are closed.


### PR DESCRIPTION


*Issue #, if available:*
N/A

*Description of changes:*
It was not immediately obvious how to use the files in `sdk`. The recent service notice is actually how I learned about `aws configure add-model` - really obvious to an Amazonian, not so much to others.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
