### PR TITLE
Add AWS CLI instructions to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ _What do I need to get started?_
 _How do I contribute my own example notebook?_  
  Although we're extremely excited to receive contributions from the community, we're still working on the best mechanism to take in examples from external sources. Please bear with us in the short-term if pull requests take longer than expected or are closed.
  
+ _How do I use control AWS Forecast resources using the aws cli?_
+
+  You can clone or download this repository and run `aws configure add-model --service-model [MODEL_JSON_FILE]`
+ on the files in `sdk`, eg `aws configure add-model --service-model file://forecast-2019-07-22.normal.json`
+ 
  ## Contact us
  Contact the dev team @ forecastpreview-support@amazon.com
 


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
It was not immediately obvious how to use the files in sdk. The recent service notice is actually how I learned about aws configure add-model - really obvious to an Amazonian, not so much to others.

I think this is important since a lot of BI folks who don't have in-depth knowledge about awscli may want to experiment with this service and it's not immediately obvious how to get awscli to work with forecast.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.