### PR TITLE
changed lab to use deepar plus instead of prophet

### DIFF
--- a/notebooks/2.Building_Your_Predictor.ipynb
+++ b/notebooks/2.Building_Your_Predictor.ipynb
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictorName= project+'_prophet_algo'"
+    "predictorName= project+'_deeparp_algo'"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "algorithmArn = 'arn:aws:forecast:::algorithm/Prophet'"
+    "algorithmArn = 'arn:aws:forecast:::algorithm/Deep_AR_Plus'"
    ]
   },
   {
@@ -217,7 +217,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "forecastName= project+'_prophet_algo_forecast'"
+    "forecastName= project+'_deeparp_algo_forecast'"
    ]
   },
   {


### PR DESCRIPTION
No issue, for our partner day today I have changed the lab to use DeepAR+ instead of Prophet. We can always go back and revert this change later. Urgent request so please approve by 930am PST.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
