### PR TITLE
update the cold start notebook with the instruction for Windows

### DIFF
--- a/notebooks/8.Forecast with Cold Start Items.ipynb
+++ b/notebooks/8.Forecast with Cold Start Items.ipynb
@@ -132,12 +132,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Do `!pip install sh` if you don't have sh. If you are using Windows, use the following snippet or directly unzip the zip file.\n",
+    "\n",
+    "    import gzip\n",
+    "    # gzip.decompress(zipLocalFilePath)\n",
+    "\n",
+    "    input = gzip.GzipFile(\"../data/cold-start/test.csv.gz\", 'rb')\n",
+    "    s = input.read()\n",
+    "    input.close()\n",
+    "\n",
+    "    output = open(\"../data/cold-start/test.csv\", 'wb')\n",
+    "    output.write(s)\n",
+    "    output.close()\n",
+    "    print(\"done\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# do `!pip install sh` if you don't have sh \n",
     "from sh import gunzip\n",
     "gunzip(zipLocalFilePath)"
    ]
@@ -1496,9 +1514,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since `sh` package does not work on Windows, we update the notebook to include the instruction for Windows (credit to @rohitmenon83 and @yuzhoujianxia). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
