### PR TITLE
Fix README links and numbered list

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -16,10 +16,10 @@ In the Notebooks you will learn to:
 The steps below outline the process of building your own time-series prediction models, evaluating them, and then cleaning up all of yuour resources to prevent any unwanted charges. To get started execute the following steps.
 
 1. Deploy the CloudFormation Template below or build a local Jupyter environment with the AWS CLI installed and configured for your IAM account.
-1. [1.Getting_Data_Ready.ipynb](notebooks/basic/Tutorial/1.Getting_Data_Ready.ipynb) - Guides you through preparing your dataset to be used with Amazon Forecast.
-1. [2.Building_Your_Predictor.ipynb](notebooks/basic/Tutorial/2.Building_Your_Predictor.ipynb) - Explains how to use the dataset you prepared to build your first model.
-1. [3.Evaluating_Your_Predictor.ipynb](notebooks/basic/Tutorial/3.Evaluating_Your_Predictor.ipynb) - Takes the model you just created and evaluates its performance against real observed measurements.
-1. [4.Cleanup.ipynb](notebooks/basic/Tutorial/4.Cleanup.ipynb) - Deletes Amazon Forecast resources and IAM role created in above notebooks.
+1. [Getting_Data_Ready.ipynb](basic/Tutorial/1.Getting_Data_Ready.ipynb) - Guides you through preparing your dataset to be used with Amazon Forecast.
+1. [Building_Your_Predictor.ipynb](basic/Tutorial/2.Building_Your_Predictor.ipynb) - Explains how to use the dataset you prepared to build your first model.
+1. [Evaluating_Your_Predictor.ipynb](basic/Tutorial/3.Evaluating_Your_Predictor.ipynb) - Takes the model you just created and evaluates its performance against real observed measurements.
+1. [Cleanup.ipynb](basic/Tutorial/4.Cleanup.ipynb) - Deletes Amazon Forecast resources and IAM role created in above notebooks.
 
 Each notebook can be found within the `notebooks` folder in this project.
 


### PR DESCRIPTION
current links are broken, see bellow

https://github.com/aws-samples/amazon-forecast-samples/blob/master/notebooks/notebooks/basic/Tutorial/1.Getting_Data_Ready.ipynb

I suspect this part of the markdown was simply moved from the root README without updating the path (see the double `notebooks` above)

*Description of changes:*
1. removes the unnecessary `notebooks/` path from the links
1. fixes the numbered list syntax 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
