### PR TITLE
Add JupyterLab support for interactive widgets

### DIFF
--- a/notebooks/misc/CloudFormation/ForecastDemo.yaml
+++ b/notebooks/misc/CloudFormation/ForecastDemo.yaml
@@ -106,12 +106,30 @@ Resources:
         - "arn:aws:iam::aws:policy/AmazonForecastFullAccess"
         - "arn:aws:iam::aws:policy/IAMFullAccess"
 
+  # Lifecycle configuration to automate some extra notebook setup
+  NotebookConfig:
+    Type: "AWS::SageMaker::NotebookInstanceLifecycleConfig"
+    Properties:
+      OnStart:
+        - Content:
+            Fn::Base64: !Sub |
+              #!/bin/bash
+              set -e
+
+              # JupyterLab requires an extension to support interactive widgets used in the NBs:
+              sudo -u ec2-user -i <<'EOF'
+              source /home/ec2-user/anaconda3/bin/activate JupyterSystemEnv
+              jupyter labextension install @jupyter-widgets/jupyterlab-manager
+              source /home/ec2-user/anaconda3/bin/deactivate
+              EOF
+
   # SageMaker notebook
   NotebookInstance:
     Type: "AWS::SageMaker::NotebookInstance"
     Properties:
       InstanceType: "ml.t2.medium"
       NotebookInstanceName: !Ref NotebookName
+      LifecycleConfigName: !GetAtt NotebookConfig.NotebookInstanceLifecycleConfigName
       RoleArn: !GetAtt SageMakerIamRole.Arn
       VolumeSizeInGB: !Ref VolumeSize
       DefaultCodeRepository: https://github.com/aws-samples/amazon-forecast-samples.git


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Currently the tutorial notebooks use interactive widgets which don't render in JupyterLab by default.

Add a lifecycle configuration script to the CloudFormation template, to install the JupyterLab extension required to make them work.

**Note:** I guess fully consuming this change would also require updating the [S3 hosted YAML](https://chriskingpartnershare.s3.amazonaws.com/ForecastDemo.yaml) linked by the deploy button on [notebooks/README.md](https://github.com/aws-samples/amazon-forecast-samples/tree/master/notebooks/README.md).

<br/><br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
