### PR TITLE
Automated bucket naming for easier multi-user event setup

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -50,7 +50,9 @@ Start by clicking `Next` at the bottom like this:
 
 ![StackWizard](doc/images/img1.png)
 
-In the next page you need to provide a unique S3 bucket name for your file storage, it is recommended to simply add your first name and last name to the end of the default option as shown below, after that update click `Next` again.
+If you choose to provide a S3 bucket name for your file storage in the next page, remember that bucket names must be globally unique: If you enter a bucket name that already exists in any AWS account, your stack will fail to create.
+
+You can instead leave this option blank to create a bucket name automatically, and leave other options as default unless you need to change them. Once you're ready, click Next again.
 
 ![StackWizard2](doc/images/img2.png)
 

--- a/notebooks/misc/CloudFormation/ForecastDemo.yaml
+++ b/notebooks/misc/CloudFormation/ForecastDemo.yaml
@@ -7,8 +7,10 @@ Parameters:
 
   BucketName:
     Type: String
-    Default: forecastdemofirstnamelastname
-    Description: The name of the S3 Bucket to create, use only characters and numbers, no special characters or spaces.
+    Default: ""
+    Description: The (globally unique) name of the S3 Bucket to create, or blank to set a name automatically.
+    AllowedPattern: "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$"
+    ConstraintDescription": Can include numbers, letters, and hyphens (-). Must not start or end with a hyphen.
 
   NotebookName:
     Type: String
@@ -68,6 +70,7 @@ Metadata:
           - PrivateSubnet
 
 Conditions:
+  ExplicitBucketName: !Not [!Equals [!Ref BucketName, ""]]
   UseOwnVPC: !Equals [!Ref UseVPC, "true"]
   
 Resources:
@@ -75,7 +78,7 @@ Resources:
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Ref BucketName
+      BucketName: !If [ ExplicitBucketName, !Ref BucketName, !Ref "AWS::NoValue" ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           -
@@ -121,5 +124,5 @@ Resources:
 
 Outputs:
   S3Bucket:
-    Value: !Ref BucketName
+    Value: !Ref S3Bucket
     Description: S3 Bucket for object storage


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

S3 bucket names must be globally unique... so for group demo events using the CloudFormation stack, everybody currently needs to be careful about selecting a bucket name which is unique to them and isn't in use by any other AWS account.

We can simplify event setup by making this parameter optional in the stack and letting CloudFormation auto-generate a unique bucket name where not explicitly provided.

The resultant bucket name will typically combine the stack name, the logical resource name from the template (currently `S3Bucket`, but we could change this to something like `ForecastDemoBucket` in the YAML if that was a problem), and a random element. So e.g. `ForecastDemo-S3Bucket-2baf347c`

<br/><br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
