### PR TITLE
added more visibility to s3 errors on creation

### DIFF
--- a/notebooks/common/util/fcst_utils.py
+++ b/notebooks/common/util/fcst_utils.py
@@ -127,9 +127,10 @@ def create_bucket(bucket_name, region=None):
             try:
                 s3_client.create_bucket(Bucket=bucket_name,
                                         CreateBucketConfiguration=location)
-            except:
+            except Exception as e:
+                print (e)
                 s3_client.create_bucket(Bucket=bucket_name)
-    except ClientError as e:
+    except botocore.exceptions.ClientError as e:
         print(e)
         return False
     return True


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added more visibility. Because of the nested error handling, it failed silently when the bucket already existed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
