### PR TITLE
Replace individual resources deletes with ResourceTree deletion

### DIFF
--- a/notebooks/advanced/Getting_started_with_AutoML/Getting_started_with_AutoML.ipynb
+++ b/notebooks/advanced/Getting_started_with_AutoML/Getting_started_with_AutoML.ipynb
@@ -687,7 +687,7 @@
    "source": [
     "# Cleanup\n",
     "\n",
-    "Once we have completed the above steps, we can start to cleanup the resources we created. All delete jobs, except for `delete_dataset_group` are asynchronous, so we have added the helpful `wait_till_delete` function. \n",
+    "Once we have completed the above steps, we can start to cleanup the resources we created. All the created resources can be deleted using `delete_resource_tree` and it is an asynchronous operation, so we have added the helpful `wait_till_delete` function. To learn more about deleting a parent resource and all its child resources, visit [DeleteResourceTree](https://docs.aws.amazon.com/forecast/latest/dg/API_DeleteResourceTree.html) API. \n"
     "Resource Limits documented <a href=\"https://docs.aws.amazon.com/forecast/latest/dg/limits.html\">here</a>."
    ]
   },
@@ -697,8 +697,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Delete forecast export for both algorithms\n",
-    "util.wait_till_delete(lambda: forecast.delete_forecast_export_job(ForecastExportJobArn = forecastExportJobArn))"
+    "# Delete the DatasetGroup, and all its child resources such as Predictor, PredictorBacktestExportJob, Forecast and ForecastExportJob\n",
+    "util.wait_till_delete(lambda: forecast.delete_resource_tree(ResourceArn=datasetGroupArn))"
    ]
   },
   {
@@ -707,48 +707,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Delete forecast\n",
-    "util.wait_till_delete(lambda: forecast.delete_forecast(ForecastArn = forecastArn))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Delete predictor\n",
-    "util.wait_till_delete(lambda: forecast.delete_predictor(PredictorArn = predictorArn))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Delete Import\n",
-    "util.wait_till_delete(lambda: forecast.delete_dataset_import_job(DatasetImportJobArn=ds_import_job_arn))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Delete the dataset\n",
-    "util.wait_till_delete(lambda: forecast.delete_dataset(DatasetArn=datasetArn))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Delete Dataset Group\n",
-    "util.wait_till_delete(lambda: forecast.delete_dataset_group(DatasetGroupArn=datasetGroupArn))"
+    "# Delete the Dataset and its child DatasetImportJob resources:\n",
+    "util.wait_till_delete(lambda: forecast.delete_resource_tree(ResourceArn=datasetArn))"
    ]
   },
   {

--- a/notebooks/basic/Tutorial/4.Cleanup.ipynb
+++ b/notebooks/basic/Tutorial/4.Cleanup.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "## Defining the Things to Cleanup\n",
     "\n",
-    "In the previous notebooks you stored several variables at the end of each, now that they have been retrieved above, the cells below will delete the items that were created one at a time until all items that were created have been removed."
+    "In the previous notebooks you stored several variables at the end of each, now that they have been retrieved above, the cells below will delete the items that were created one at a time until all items that were created have been removed. For a parent resource, all its child resources can be deleted using `delete_resource_tree` and to learn more about it, visit [DeleteResourceTree](https://docs.aws.amazon.com/forecast/latest/dg/API_DeleteResourceTree.html) API. Bellow cell uses `delete_resource_tree` to delete the predictor resource and all its child resources such as Forecasts, PredictorBacktestExportJobs and ForecastExportJobs. \n"
    ]
   },
   {
@@ -88,18 +88,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Delete forecast\n",
-    "util.wait_till_delete(lambda: forecast.delete_forecast(ForecastArn = forecast_arn_deep_ar))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Delete predictor\n",
-    "util.wait_till_delete(lambda: forecast.delete_predictor(PredictorArn = predictor_arn_deep_ar))"
+    "# Delete predictor and all its child resources such as Forecasts, PredictorBacktestExportJobs and ForecastExportJobs \n",
+    "util.wait_till_delete(lambda: forecast.delete_resource_tree(ResourceArn = predictor_arn_deep_ar))"
    ]
   },
   {


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Replace individual resource deletes with ResourceTree deletion. For example: With the new API `delete_resource_tree`, when a predictor resource is provided - all the child resources such as Forecast, PredictorBacktestExportJob, ForecastExportJob including the given parent predictor resource will be deleted.

Changes are made only to Basic CleanUp Notebook and Advanced Getting_started_with_AutoML Notebook.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
