### PR TITLE
Enable using MLOps guidance in nested stack

### DIFF
--- a/ml_ops/forecast-mlops-dependency.yaml
+++ b/ml_ops/forecast-mlops-dependency.yaml
@@ -12,17 +12,17 @@ Parameters:
 
   ExistingS3Bucket:
     Description: Does your S3 bucket already exist?
-    Default: false
+    Default: 'false'
     Type: String
     AllowedValues:
-        - true
-        - false
+        - 'true'
+        - 'false'
     ConstraintDescription: must specify true or false
 
 Conditions:
-  CreateS3Resource: !Equals 
+  CreateS3Resource: !Equals
     - !Ref ExistingS3Bucket
-    - false
+    - 'false'
 
 Resources:
 

--- a/ml_ops/forecast-mlops-solution-guidance.yaml
+++ b/ml_ops/forecast-mlops-solution-guidance.yaml
@@ -7,20 +7,20 @@ Parameters:
 
   DatasetIncludeRTS:
     Description: Do you wish to provide a related time series (RTS) for this use-case?
-    Default: true
+    Default: 'true'
     Type: String
     AllowedValues:
-        - true
-        - false
+        - 'true'
+        - 'false'
     ConstraintDescription: must specify true or false
 
   DatasetIncludeItem:
     Description: Do you wish to provide item metadata for this use-case?
-    Default: true
+    Default: 'true'
     Type: String
     AllowedValues:
-        - true
-        - false
+        - 'true'
+        - 'false'
     ConstraintDescription: must specify true or false
 
   DatasetGroupName:
@@ -322,7 +322,7 @@ Resources:
               - states:StopExecution
               Effect: Allow
               Resource:
-              - !Join 
+              - !Join
                     - ''
                     - - !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}'
                       - '*'
@@ -339,7 +339,6 @@ Resources:
                 - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule'
             Version: '2012-10-17'
           PolicyName: !Sub '${AWS::StackName}-events-ops'
-        RoleName: !Sub "StepFunctions-${AWS::StackName}-Workflow-Role"
 
 
   CreateDatasetGroupStateMachine:
@@ -1747,7 +1746,7 @@ Resources:
       DefinitionString:
         !Sub |
           {
-            "Comment": "A description of my state machine",
+            "Comment": "An automation pipeline to query forecasting input data from Amazon Athena",
             "StartAt": "GetParameters",
             "States": {
               "GetParameters": {
@@ -2199,4 +2198,30 @@ Resources:
             }
           }
 
-      RoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/StepFunctions-${AWS::StackName}-Workflow-Role"
+      RoleArn: !GetAtt StepFunctionsWorkflowRole.Arn
+
+Outputs:
+  CreateDatasetGroupStateMachineArn:
+    Description: ARN of the AWS Step Functions State Machine to create the Amazon Forecast dataset group
+    Value: !Ref CreateDatasetGroupStateMachine
+  AthenaConnectorStateMachineArn:
+    Description: ARN of the AWS Step Functions State Machine to query data from Amazon Athena
+    Value: !Ref AthenaConnectorStateMachine
+  DatasetImportStateMachineArn:
+    Description: ARN of the AWS Step Functions State Machine to import data to Amazon Forecast
+    Value: !Ref CreateImportDatasetStateMachine
+  CreatePredictorStateMachineArn:
+    Description: ARN of the AWS Step Functions State Machine to train an Amazon Forecast predictor
+    Value: !Ref CreatePredictorStateMachine
+  CreateForecastStateMachineArn:
+    Description: ARN of the AWS Step Functions State Machine to generate a forecast
+    Value: !Ref CreateForecastStateMachine
+  StepFunctionWorkflowStateMachineArn:
+    Description: ARN of the AWS Step Functions State Machine for end-to-end flow from Athena to forecast output
+    Value: !Ref StepFunctionWorkflowStateMachine
+  StepFunctionsWorkflowRoleArn:
+    Description: ARN of the IAM Execution Role used for the End-to-end forecasting Step Functions workflow
+    Value: !GetAtt StepFunctionsWorkflowRole.Arn
+  StackName:
+    Description: (Output to expose the StackName when nesting this stack inside others) This is used for naming some useful resources
+    Value: !Ref AWS::StackName


### PR DESCRIPTION
**Issue #, if available:** N/A

I'd like to be able to re-use the `ml_ops` solution guidance stack within other stacks: A deployable stack that provisions the dependencies, the guidance stack, and then some other resources e.g. a customised end-to-end state machine using the pre-built components.

Today, that's a challenge because the stacks don't expose any outputs. There's no config in [AWS::CloudFormation::Stack](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html) to explicitly set stack name: It gets generated automatically and isn't visible via `GetAtt` on the resource either. So just locating resources by assumed name from the StackName isn't practical.

**Description of changes:**

To make building stacks that nest this guidance practical, proposing these updates:

- Expose useful outputs from MLOps solution guidance stack, including state machine ARNs and the final AWS Stack Name.
- Shorten role name that was causing problems when nesting the stack (64 character limit).
- Explicitly set string types to ambiguous bool parameters (YAML interprets plain true as a bool, not string, and in one instance I got errors during CFn deployment complaining about string types).
- Fill in a SFn description that was previously just placeholder.

Now, by nesting the solution in a parent stack something like this:

```yaml
  PipelineStack:
    Type: 'AWS::CloudFormation::Stack'
    DependsOn:
      - DependencyStack
    Properties:
      Parameters:
        # DatasetIncludeRTS: true/false  - and other parameters etc.
        DatasetGroupName: forecast_e2e_demo
        SNSEndpoint: !Ref SNSEndpoint
        S3Bucket: !Ref S3Bucket
      TemplateURL: https://s3.amazonaws.com/doc-example-bucket/forecast-mlops-solution-guidance.yaml
```

...The parent stack can e.g. set up state machines referencing `PipelineStack.Outputs.CreateDatasetGroupStateMachineArn`, and use `PipelineStack.Outputs.StackName` if necessary.

<br/>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
